### PR TITLE
feat: drop env cli option

### DIFF
--- a/lib/flakie/cli/options.rb
+++ b/lib/flakie/cli/options.rb
@@ -3,24 +3,9 @@
 module Flakie
   module CLI
     Options =
-      Struct.new(:count, :env, :format, :output, :help, :version) do
-        def self.default = new(count: 5, env: {}, format: :tictactoe, output: $stdout, help: false, version: false)
+      Struct.new(:count, :format, :output, :help, :version) do
+        def self.default = new(count: 5, format: :tictactoe, output: $stdout, help: false, version: false)
         def self.from(args) = default.tap { |options| Parser.parse!(args, into: options) }
-
-        def []=(key, value)
-          if key == :env
-            add_env(value)
-          else
-            super
-          end
-        end
-
-        def add_env(raw)
-          name, value = raw.split("=")
-          CLI.exit_with_error("Bad env variable format: #{raw}") if name.nil? || value.nil?
-
-          env[name] = value
-        end
 
         def formatter = Formatters::ALL.fetch(format)
 

--- a/lib/flakie/cli/parser.rb
+++ b/lib/flakie/cli/parser.rb
@@ -18,8 +18,6 @@ module Flakie
 
         opts.on("-o", "--output FILE", "File to output result. Defaults to STDOUT.") { |path| File.open(path, "w") }
 
-        opts.on("-e", "--env KEY_VALUE", "Additional environment variables to set. Can be called multiple times.")
-
         opts.on("-v", "--version", "Show the version")
         opts.on("-h", "--help", "Show this help message")
         opts.separator ""

--- a/lib/flakie/cli/runner.rb
+++ b/lib/flakie/cli/runner.rb
@@ -15,12 +15,7 @@ module Flakie
         in version: true
           Parser.version.display
         else
-          Engine.new(
-            args.join(" "),
-            count: options.count,
-            env: options.env,
-            reporter: options.formatter.new(options.output),
-          ).run
+          Engine.new(args.join(" "), count: options.count, reporter: options.formatter.new(options.output)).run
         end
       end
 

--- a/lib/flakie/engine.rb
+++ b/lib/flakie/engine.rb
@@ -10,10 +10,9 @@ module Flakie
 
     Report = Data.define(:runs) { def last_run = runs.last }
 
-    def initialize(command, count:, env:, reporter:)
+    def initialize(command, count:, reporter:)
       @command = command
       @count = count
-      @env = env
       @reporter = reporter
       @report = Report.new([])
     end
@@ -23,7 +22,7 @@ module Flakie
 
       count.times do |index|
         start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-        system(env, command, out: File::NULL, err: File::NULL)
+        system(command, out: File::NULL, err: File::NULL)
         end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
         duration = (end_time - start_time).round
         report.runs.append Run.new(status: $?.success?, duration: duration, number: index + 1)
@@ -35,6 +34,6 @@ module Flakie
 
     private
 
-    attr_reader :command, :count, :env, :reporter, :report
+    attr_reader :command, :count, :reporter, :report
   end
 end


### PR DESCRIPTION
## Why do we need these changes?

There are native and simpler ways of doing this.

To accomplish the following command:

```bash
flakie --env HEADLESS=1 rails t test/my_test.rb
```

we can simply do:

```bash
HEADLESS=1 flakie rails t test/my_test.rb
```


## What does this PR cover?

- Remove support for `--env` option


## Breaking Changes

None.
