### PR TITLE
fix: fix gemspec

### DIFF
--- a/flakie.gemspec
+++ b/flakie.gemspec
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require_relative "lib/flakie"
+require_relative "lib/flakie/version"
 
 Gem::Specification.new do |spec|
-  spec.name = Flakie::NAME
+  spec.name = "flakie"
   spec.version = Flakie::VERSION
   spec.authors = ["Khurram Raza"]
   spec.email = ["ikhurramraza@gmail.com"]


### PR DESCRIPTION
On a fresh repo pull, `bundle install`  fails since it tries to load the
gemspec file  which in turn loads  the flakie root file  which loads the
zeitwerk gem  which is  not installed  yet. Classic  circular dependency
error.
