### PR TITLE
docs: fix publish instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ gem install flakie
 2. Create and push tag to GitHub.
 
 ```bash
-git tag --sign -a "v[VERSION_TAG]" -m "[VERSION_TAG]"
+git tag --sign -a "v[VERSION_TAG]" -m "v[VERSION_TAG]"
 
 git push origin "v[VERSION_TAG]"
 ```


### PR DESCRIPTION
The tag message is used by the GitHub Action named "release" to create
the release name and "v1.2.3" is the preferred format.
